### PR TITLE
Added test for mapper field with no mapping

### DIFF
--- a/spec/dataly/mapper_spec.rb
+++ b/spec/dataly/mapper_spec.rb
@@ -11,6 +11,7 @@ class FieldMapper < Dataly::Mapper
   field :user_id, value: :find_user_id
   field :age, value: Proc.new { |value| value.to_i }
   field :status, value: :update_status
+  field :field_with_no_mapping
 
   def update_status(value)
     value.downcase
@@ -26,7 +27,9 @@ class SecondFieldMapper < Dataly::Mapper
 end
 
 describe Dataly::Mapper do
-  let(:valid_attributes) { %i(name status address user_id age) }
+  let(:valid_attributes) {
+    %i(name status address user_id age field_with_no_mapping)
+  }
   let(:mapper) { FieldMapper.new(Sample) }
 
   let(:row) do
@@ -36,7 +39,8 @@ describe Dataly::Mapper do
       age: '21',
       pets: 'false',
       address: '',
-      user: 'beaker@example.com'
+      user: 'beaker@example.com',
+      field_with_no_mapping: 'foo'
     }
   end
 
@@ -44,7 +48,7 @@ describe Dataly::Mapper do
     allow(Sample).to receive(:attribute_names).and_return(valid_attributes)
   end
 
-  specify { expect(mapper.process(row)).to eq({ name: 'beaker', address: nil, status: 'active', user_id: 1, age: 21 }) }
-  specify { expect(mapper.fields.keys).to eq([:user_id, :age, :status]) }
+  specify { expect(mapper.process(row)).to eq({ name: 'beaker', address: nil, status: 'active', user_id: 1, age: 21, field_with_no_mapping: 'foo' }) }
+  specify { expect(mapper.fields.keys).to eq([:user_id, :age, :status, :field_with_no_mapping]) }
   specify { expect(mapper.renames.keys).to eq([:user]) }
 end


### PR DESCRIPTION
Hi,

Not sure why allow `field` definitions without mappings, but you seem to be missing a test for this case.
