### PR TITLE
Allow mappings to be created for fields not on the model.

### DIFF
--- a/lib/dataly/mapper.rb
+++ b/lib/dataly/mapper.rb
@@ -1,5 +1,3 @@
-require 'byebug'
-
 module Dataly
   class Mapper
     attr_reader :model
@@ -48,7 +46,7 @@ module Dataly
       val = mapping_exists?(key) ? transform(key, v) : v
       val = blank_to_nil(val)
 
-      return [key.to_sym, val] if attributes.include?(key)
+      return [key.to_sym, val]
     end
 
     def map_to(k)

--- a/spec/dataly/importer_spec.rb
+++ b/spec/dataly/importer_spec.rb
@@ -30,7 +30,7 @@ describe Dataly::Importer do
   include FakeFS::SpecHelpers
 
   let(:reporter) { instance_double(Dataly::Reporter) }
-  let(:importer) { SampleImporter.new('sample.csv', { reporter: Dataly::Reporter }) }
+  let(:importer) { SampleImporter.new('sample.csv', { reporter: reporter }) }
   let(:sample_file) { double(:sample) }
 
   before do

--- a/spec/dataly/mapper_spec.rb
+++ b/spec/dataly/mapper_spec.rb
@@ -44,7 +44,7 @@ describe Dataly::Mapper do
     allow(Sample).to receive(:attribute_names).and_return(valid_attributes)
   end
 
-  specify { expect(mapper.process(row)).to eq({ name: 'beaker', address: nil, status: 'active', user_id: 1, age: 21 }) }
+  specify { expect(mapper.process(row)).to eq({ name: 'beaker', address: nil, status: 'active', user_id: 1, age: 21, pets: 'false'   }) }
   specify { expect(mapper.fields.keys).to eq([:user_id, :age, :status]) }
   specify { expect(mapper.renames.keys).to eq([:user]) }
 end


### PR DESCRIPTION
Allow for cases where virtual mappings exist in source file.
It is assumed that the corresponding creator will filter out this mappings before creating.
