### PR TITLE
Add additional parameter for CSV row to mapping functions.

### DIFF
--- a/lib/dataly/mapper.rb
+++ b/lib/dataly/mapper.rb
@@ -37,15 +37,15 @@ module Dataly
 
     def process(row)
       Hash[row.map do |heading, value|
-        process_column(heading, value)
+        process_column(heading, value, row)
       end.compact]
     end
 
     private
-    def process_column(k, v)
+    def process_column(k, v, row)
       key = map_to(k)
 
-      val = mapping_exists?(key) ? transform(key, v) : v
+      val = mapping_exists?(key) ? transform(key, v, row) : v
       val = blank_to_nil(val)
 
       return [key.to_sym, val] if attributes.include?(key)
@@ -55,15 +55,24 @@ module Dataly
       renames[k] ? renames[k] : k
     end
 
-    def transform(csv_field_name, csv_value)
+    def transform(csv_field_name, csv_value, values)
       transformer = fields[csv_field_name][:value]
 
       if transformer.respond_to?(:call)
+        call_transformer(transformer, csv_value, values)
         transformer.call(csv_value)
       elsif transformer && respond_to?(transformer)
         send(transformer, csv_value)
       else
         csv_value
+      end
+    end
+
+    def call_transformer(transformer, value, values)
+      if transformer.arity == 1
+        transformer.call(value)
+      else
+        transformer.call(value, values)
       end
     end
 

--- a/lib/dataly/mapper.rb
+++ b/lib/dataly/mapper.rb
@@ -60,7 +60,6 @@ module Dataly
 
       if transformer.respond_to?(:call)
         call_transformer(transformer, csv_value, values)
-        transformer.call(csv_value)
       elsif transformer && respond_to?(transformer)
         send(transformer, csv_value)
       else

--- a/lib/dataly/mapper.rb
+++ b/lib/dataly/mapper.rb
@@ -44,7 +44,6 @@ module Dataly
     private
     def process_column(k, v, row)
       key = map_to(k)
-
       val = mapping_exists?(key) ? transform(key, v, row) : v
       val = blank_to_nil(val)
 
@@ -59,19 +58,11 @@ module Dataly
       transformer = fields[csv_field_name][:value]
 
       if transformer.respond_to?(:call)
-        call_transformer(transformer, csv_value, values)
+        transformer.call(csv_value, values)
       elsif transformer && respond_to?(transformer)
-        send(transformer, csv_value)
+        method(transformer).call(csv_value, values)
       else
         csv_value
-      end
-    end
-
-    def call_transformer(transformer, value, values)
-      if transformer.arity == 1
-        transformer.call(value)
-      else
-        transformer.call(value, values)
       end
     end
 

--- a/lib/dataly/version.rb
+++ b/lib/dataly/version.rb
@@ -1,3 +1,3 @@
 module Dataly
-  VERSION = "0.0.1"
+  VERSION = '0.0.2'
 end

--- a/spec/dataly/importer_spec.rb
+++ b/spec/dataly/importer_spec.rb
@@ -30,7 +30,7 @@ describe Dataly::Importer do
   include FakeFS::SpecHelpers
 
   let(:reporter) { instance_double(Dataly::Reporter) }
-  let(:importer) { SampleImporter.new('sample.csv', { reporter: Dataly::Reporter }) }
+  let(:importer) { SampleImporter.new('sample.csv', { reporter: reporter }) }
   let(:sample_file) { double(:sample) }
 
   before do

--- a/spec/dataly/mapper_spec.rb
+++ b/spec/dataly/mapper_spec.rb
@@ -13,20 +13,16 @@ class FieldMapper < Dataly::Mapper
   field :status, value: :update_status
   field :properties, value: :other
 
-  def update_status(value)
+  def update_status(value, csv_values)
     value.downcase
   end
 
-  def find_user_id(value)
+  def find_user_id(value, csv_values)
     USERS[value]
   end
 
   def other(value, values)
-    if values[:user_id] == 1
-      2
-    else
-      value
-    end
+    "#{value} - #{values[:other_value]}"
   end
 end
 
@@ -45,7 +41,9 @@ describe Dataly::Mapper do
       age: '21',
       pets: 'false',
       address: '',
-      user: 'beaker@example.com'
+      user: 'beaker@example.com',
+      other_value: 'Some other Value',
+      properties: 'XXX'
     }
   end
 
@@ -53,7 +51,7 @@ describe Dataly::Mapper do
     allow(Sample).to receive(:attribute_names).and_return(valid_attributes)
   end
 
-  specify { expect(mapper.process(row)).to eq({ name: 'beaker', address: nil, status: 'active', user_id: 1, age: 21 }) }
+  specify { expect(mapper.process(row)).to eq({ name: 'beaker', address: nil, status: 'active', user_id: 1, age: 21, properties: 'XXX - Some other Value' }) }
   specify { expect(mapper.fields.keys).to eq([:user_id, :age, :status, :properties]) }
   specify { expect(mapper.renames.keys).to eq([:user]) }
 end

--- a/spec/dataly/mapper_spec.rb
+++ b/spec/dataly/mapper_spec.rb
@@ -11,6 +11,7 @@ class FieldMapper < Dataly::Mapper
   field :user_id, value: :find_user_id
   field :age, value: Proc.new { |value| value.to_i }
   field :status, value: :update_status
+  field :properties, value: :other
 
   def update_status(value)
     value.downcase
@@ -19,6 +20,14 @@ class FieldMapper < Dataly::Mapper
   def find_user_id(value)
     USERS[value]
   end
+
+  def other(value, values)
+    if values[:user_id] == 1
+      2
+    else
+      value
+    end
+  end
 end
 
 class SecondFieldMapper < Dataly::Mapper
@@ -26,7 +35,7 @@ class SecondFieldMapper < Dataly::Mapper
 end
 
 describe Dataly::Mapper do
-  let(:valid_attributes) { %i(name status address user_id age) }
+  let(:valid_attributes) { %i(name status address properties user_id age) }
   let(:mapper) { FieldMapper.new(Sample) }
 
   let(:row) do
@@ -45,6 +54,6 @@ describe Dataly::Mapper do
   end
 
   specify { expect(mapper.process(row)).to eq({ name: 'beaker', address: nil, status: 'active', user_id: 1, age: 21 }) }
-  specify { expect(mapper.fields.keys).to eq([:user_id, :age, :status]) }
+  specify { expect(mapper.fields.keys).to eq([:user_id, :age, :status, :properties]) }
   specify { expect(mapper.renames.keys).to eq([:user]) }
 end


### PR DESCRIPTION
This feature provides the ability for a mapping function to read values from the original CSV row.

Example use case :

When importing locations we need to set the correct suburb. To retrieve the correct suburb we need both the name and postcode. As the `Location` model only cares about the id of the suburb i.e. 'suburb_id', we need to provide a mechanism whereby we can pass additional parameters to locate the correct suburb.

``` ruby
class LocationMapper < Dataly::Mapper
  field :suburb_id, value: :suburb

  def suburb(value,csv_row)
       Suburb.where('lower(name) = ? and postcode = ?', value.downcase, csv_row[:postcode_id]).first
  end
end
```

This is considerably nicer than having to split a field.

``` ruby
   class LocationMapper < Dataly::Mapper
      field :suburb_id, value: :suburb

     def suburb(value)
          suburb, postcode = value.split(',')
          Suburb.where()
    end
end
```
